### PR TITLE
Add toJSON wrapper function

### DIFF
--- a/R/assertions.R
+++ b/R/assertions.R
@@ -41,6 +41,12 @@ assert_named <- function(x) {
   )
 }
 
+assert_unnamed <- function(x) {
+  stopifnot(
+    is.null(names(x)) || all(names(x) == "")
+  )
+}
+
 assert_mouse_button <- function(x) {
   if (is.numeric(x)) {
     x <- as.integer(x)

--- a/R/element-keys.R
+++ b/R/element-keys.R
@@ -104,7 +104,7 @@ element_send_keys <- function(self, private, ...) {
   "!DEBUG element_send_keys `private$id`"
   response <- private$session_private$make_request(
     "ELEMENT SEND KEYS",
-    list(value = paste(keys, collapse = "")),
+    list(value = I(paste(keys, collapse = ""))),
     params = list(element_id = private$id)
   )
 

--- a/R/element.R
+++ b/R/element.R
@@ -285,7 +285,7 @@ element_set_value <- function(self, private, value) {
 
   private$session_private$make_request(
     "SET ELEMENT VALUE",
-    list(value = value),
+    list(value = I(value)),
     params = list(element_id = private$id)
   )
 

--- a/R/requests.R
+++ b/R/requests.R
@@ -90,3 +90,10 @@ parse_response <- function(response) {
     content(response, as = "text")
   }
 }
+
+
+toJSON <- function(x, ..., auto_unbox = TRUE) {
+  # I(x) is so that length-1 atomic vectors get put in [] when auto_unbox is
+  # TRUE.
+  jsonlite::toJSON(I(x), auto_unbox = auto_unbox, ...)
+}

--- a/R/session.R
+++ b/R/session.R
@@ -437,8 +437,8 @@ session_find_element <- function(self, private, css, link_text,
   response <- private$make_request(
     "FIND ELEMENT",
     list(
-      using = unbox(find_expr$using),
-      value = unbox(find_expr$value)
+      using = find_expr$using,
+      value = find_expr$value
     )
   )
 
@@ -589,17 +589,15 @@ session_get_all_windows <- function(self, private) {
 
 prepare_execute_args <- function(...) {
   args <- list(...)
-  for (i in seq_along(args)) {
-    x <- args[[i]]
+  assert_unnamed(args)
+
+  lapply(args, function(x) {
     if (inherits(x, "element") && inherits(x, "R6")) {
-      args[[i]] <- list(ELEMENT = unbox(x$.__enclos_env__$private$id))
-    } else if (length(x) == 1) {
-      args[[i]] <- unbox(x)
+      list(ELEMENT = unbox(x$.__enclos_env__$private$id))
     } else {
       x
     }
-  }
-  args
+  })
 }
 
 parse_script_response <- function(self, private, value) {


### PR DESCRIPTION
This addresses #39 (though I'm not sure if this solves the exact problem you had). The default is for length-1 vectors to be unboxed; if you want them to be boxed, wrap them in `I()`.

It fixes an issue I mentioned in MangoTheCat/shinytest#50, where I couldn't set a checkbox to FALSE. This is because the JSON that got sent contained `{value: [false]}` instead of `{value: false}`.

All of the existing tests pass except the implicit-timeout test.